### PR TITLE
Schedule a regular cleanup

### DIFF
--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -171,4 +171,12 @@ class Validation
 
   end
 
+  def self.clean_up(hours)
+    Validation.where(:created_at.lt => hours.hours.ago, :csv_id.ne => nil).each do |validation|
+      Mongoid::GridFs.delete(validation.csv_id)
+      validation.csv_id = nil
+      validation.save
+    end
+  end
+
 end

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -172,10 +172,14 @@ class Validation
   end
 
   def self.clean_up(hours)
-    Validation.where(:created_at.lt => hours.hours.ago, :csv_id.ne => nil).each do |validation|
-      Mongoid::GridFs.delete(validation.csv_id)
-      validation.csv_id = nil
-      validation.save
+    begin
+      Validation.where(:created_at.lt => hours.hours.ago, :csv_id.ne => nil).each do |validation|
+        Mongoid::GridFs.delete(validation.csv_id)
+        validation.csv_id = nil
+        validation.save
+      end
+    ensure
+      Validation.delay(run_at: 24.hours.from_now).clean_up(24)
     end
   end
 

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -172,15 +172,15 @@ class Validation
   end
 
   def self.clean_up(hours)
-    begin
-      Validation.where(:created_at.lt => hours.hours.ago, :csv_id.ne => nil).each do |validation|
-        Mongoid::GridFs.delete(validation.csv_id)
-        validation.csv_id = nil
-        validation.save
-      end
-    ensure
-      Validation.delay(run_at: 24.hours.from_now).clean_up(24)
+    Validation.where(:created_at.lt => hours.hours.ago, :csv_id.ne => nil).each do |validation|
+      Mongoid::GridFs.delete(validation.csv_id)
+      validation.csv_id = nil
+      validation.save
     end
+  rescue => e
+    Airbrake.notify(e) if ENV['CSVLINT_AIRBRAKE_KEY'] # Exit cleanly, but still notify airbrake
+  ensure
+    Validation.delay(run_at: 24.hours.from_now).clean_up(24)
   end
 
 end

--- a/features/clean_up.feature
+++ b/features/clean_up.feature
@@ -1,10 +1,21 @@
-@data_expiry
+@timecop
 Feature: Clean up old uploaded CSVs
 
-  Scenario: uploaded CSV validations should have a TTL field as attribute
+  Scenario: Delete CSV after 24 hours
     Given I go to the homepage
     And I attach the file "csvs/valid.csv" to the "file" field
     And I press "Validate"
+    And 25 hours have passed
+    When we clean up old files
     Then there should be 1 validation
-    And that validation should have an expirable field
+    And that validation should not contain a file
+    And there should be 0 stored files in GridFs
 
+  Scenario: CSV not deleted after recent validation
+    Given I go to the homepage
+    And I attach the file "csvs/valid.csv" to the "file" field
+    And I press "Validate"
+    When we clean up old files
+    Then there should be 1 validation
+    And that validation should contain a file
+    And there should be 1 stored files in GridFs

--- a/features/clean_up.feature
+++ b/features/clean_up.feature
@@ -19,3 +19,7 @@ Feature: Clean up old uploaded CSVs
     Then there should be 1 validation
     And that validation should contain a file
     And there should be 1 stored files in GridFs
+
+  Scenario: Clean up job is requeued
+    When we clean up old files
+    Then the clean up task should have been requeued

--- a/features/clean_up.feature
+++ b/features/clean_up.feature
@@ -23,3 +23,8 @@ Feature: Clean up old uploaded CSVs
   Scenario: Clean up job is requeued
     When we clean up old files
     Then the clean up task should have been requeued
+
+  Scenario: Job is requeued even if we hit an exception
+    Given the clean up job causes an error
+    When we clean up old files
+    Then the clean up task should have been requeued

--- a/features/step_definitions/clean_up_steps.rb
+++ b/features/step_definitions/clean_up_steps.rb
@@ -21,3 +21,7 @@ end
 Then(/^the clean up task should have been requeued$/) do
   Delayed::Job.all.count.should == 1
 end
+
+Given(/^the clean up job causes an error$/) do
+  Validation.stub(:where) { raise StandardError }
+end

--- a/features/step_definitions/clean_up_steps.rb
+++ b/features/step_definitions/clean_up_steps.rb
@@ -6,10 +6,6 @@ Then(/^there should be (\d+) validation$/) do |files|
   Validation.all.count.should == files.to_i
 end
 
-Then(/^that validation should have an expirable field$/) do
-  Validation.first.expirable_created_at.should_not == nil
-end
-
 Then(/^that validation should not contain a file$/) do
   Validation.first.csv_id.should == nil
 end

--- a/features/step_definitions/clean_up_steps.rb
+++ b/features/step_definitions/clean_up_steps.rb
@@ -17,3 +17,7 @@ end
 Then(/^there should be (\d+) stored files in GridFs$/) do |files_no|
   Mongoid::GridFs::File.count.should == files_no.to_i
 end
+
+Then(/^the clean up task should have been requeued$/) do
+  Delayed::Job.all.count.should == 1
+end

--- a/features/step_definitions/time_steps.rb
+++ b/features/step_definitions/time_steps.rb
@@ -7,8 +7,5 @@ Given(/^it's three hours in the future$/) do
 end
 
 Given(/^(\d+) hours have passed$/) do |hours|
-  # byebug
   Timecop.freeze(hours.to_i.hours.from_now)
-  # TimeCop only sets and spoofs the ruby clock - when the app starts both ruby and mongo have the system time available
-  # to them - this time is only altered from POV of ruby code :. the Mongo 'created_at' fields will stay in real time
 end


### PR DESCRIPTION
This PR schedules a regular cleanup of old files. We'll still need to run a rake task initially once this has deployed (`rake clean_up:csvs`), but this will schedule a run every 24 hours.