### PR TITLE
Rake cleanup job not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,5 +52,3 @@ make sure cucumber dependencies up to date
 * Deployment instructions
 
 * ...
-
-(Please ignore hub test)

--- a/README.md
+++ b/README.md
@@ -52,3 +52,5 @@ make sure cucumber dependencies up to date
 * Deployment instructions
 
 * ...
+
+(Please ignore hub test)

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -209,6 +209,7 @@ class Validation
   end
 
   def self.clean_up(hours)
+    Mongoid::GridFs::File.where(:uploadDate.lt => hours.hours.ago).each {|x| Mongoid::GridFs.delete(x.id) }
     Validation.where(:created_at.lt => hours.hours.ago, :csv_id.ne => nil).each do |validation|
       Mongoid::GridFs.delete(validation.csv_id)
       validation.csv_id = nil


### PR DESCRIPTION
For some reason, the rake task didn't work when I ran it. It removed the validation csv_ids, but didn't remove the GridFs objects properly. When I ran Validation.clean_up(18) on the console, it *did* work as expected. Not sure why that happens; the code is running in both cases but one doesn't affect GridFs. Odd.