### PR TITLE
Don't save validator data in MongoDB

### DIFF
--- a/app/controllers/validation_controller.rb
+++ b/app/controllers/validation_controller.rb
@@ -46,7 +46,7 @@ class ValidationController < ApplicationController
   private
 
     def standardised_csv(validation)
-      data = Marshal.load(validation.result).data
+      data = CSV.parse(validation.csv, validation.parse_options.symbolize_keys)
       CSV.generate(standard_csv_options) do |csv|
         data.each do |row|
           csv << row if row

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -176,12 +176,17 @@ class Validation
 
   def csv
     # method that retrieves stored entire CSV file from mongoDB
-    unless self.csv_id.nil?
+    if self.url
+      csv = open(self.url).read
+    elsif self.csv_id
       # above line means this method triggers only when user opts to revalidate their CSV with suggested prompts
-      stored_csv = Mongoid::GridFs.get(self.csv_id)
+      csv = Mongoid::GridFs.get(self.csv_id).data
+    end
+
+    if csv
       file = Tempfile.new('csv')
       File.open(file, "w") do |f|
-        f.write stored_csv.data
+        f.write csv
       end
       file
     end

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -58,6 +58,9 @@ class Validation
       validator.remove_instance_variable(:@source)
     end
 
+    # Don't save the data
+    validator.remove_instance_variable(:@data) rescue nil
+
     attributes = {
       :url => url,
       :filename => filename,

--- a/features/validation.feature
+++ b/features/validation.feature
@@ -201,3 +201,20 @@ Feature: CSV Validation
     And that CSV file should have a field "status"
     And that CSV file should have double-quoted fields
     And that CSV file should use CRLF line endings
+
+  Scenario: Standardised CSV download with file
+    When I go to the homepage
+    And I attach the file "csvs/revalidate.csv" to the "file" field
+    And I press "Validate"
+    And I enter ";" in the "Field delimiter" field
+    And I enter "'" in the "Quote character" field
+    And I select "LF (\n)" from the "Line terminator" dropdown
+    And I press "Revalidate"
+    Then I should see a page of validation results
+    When I click on "Download Standardised CSV"
+    Then a CSV file should be downloaded
+    And that CSV file should have a field "firstname"
+    And that CSV file should have a field "lastname"
+    And that CSV file should have a field "status"
+    And that CSV file should have double-quoted fields
+    And that CSV file should use CRLF line endings

--- a/spec/models/validation_spec.rb
+++ b/spec/models/validation_spec.rb
@@ -67,4 +67,10 @@ describe Validation, type: :model do
     Validation.count.should == 1
   end
 
+  it "parse options should be created with validation" do
+    @file = mock_upload('csvs/valid.csv')
+    validation = Validation.create_validation(@file)
+    validation.parse_options.should_not == nil
+  end
+
 end


### PR DESCRIPTION
In trying to solve the large file upload issue, we discovered that when Marshaling the Validation object, the CSV data is also saved, meaning that all CSVs that are being validated are also being saved to the Mongo database, regardless of whether they're file uploads or not. This also means that, in the case of file uploads, we're also saving the CSVs TWICE, so no wonder we're running out of space!

This PR unsets the `data` instance variable before Marshaling and saving the Validation object. HOWEVER, we also had to work out a different way of creating the standardised file, as this relied on `validation.data` being present. 

We now have a unified way of getting the CSV string from the validation, either from GridFS if it's a file, or redownloading if it's a URL. We also save the parse options, so we can parse the CSV string with the non-standard options, and reconstruct the CSV with standard options at the other end when generating the standardised file.