### PR TITLE
Set parse options if they don't exist

### DIFF
--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -194,6 +194,14 @@ class Validation
     end
   end
 
+  def parse_options
+    if self.read_attribute(:parse_options).nil?
+      self.parse_options = Validation.generate_options(self.validator.dialect)
+      save
+    end
+    self.read_attribute(:parse_options)
+  end
+
   def check_validation
     # this method should only be called against URL listed validations i.e. 'added to list of recent validations'
     unless url.blank?

--- a/spec/models/validation_spec.rb
+++ b/spec/models/validation_spec.rb
@@ -73,4 +73,12 @@ describe Validation, type: :model do
     validation.parse_options.should_not == nil
   end
 
+  it "should generate parse options for older validations" do
+    @file = mock_upload('csvs/valid.csv')
+    validation = Validation.create_validation(@file)
+    validation.parse_options = nil
+    validation.save
+    validation.parse_options.should_not == nil
+  end
+
 end


### PR DESCRIPTION
We had a couple of Airbrake issues where users (probably spiders TBH) were trying to get standardised CSVs, but were failing, because `parse_options` isn't set. This is a failsafe that checks if `parse_options` is set first, and if it isn't, gets the dialect from the validation, and saves.