### PR TITLE
`revalidate` is passed as a string

### DIFF
--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -91,7 +91,7 @@ class Validation
     # returns a mongo database record
     v = self.find(id)
 
-    unless revalidate.to_s === "false"
+    unless revalidate.to_s == "false"
       if ["png", "svg"].include?(format)
         # suspect the above functions tied to the use of badges as hyperlinks to valid schemas & csvs
         v.delay.check_validation

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -91,7 +91,7 @@ class Validation
     # returns a mongo database record
     v = self.find(id)
 
-    unless revalidate === "false"
+    unless revalidate.to_s === "false"
       if ["png", "svg"].include?(format)
         # suspect the above functions tied to the use of badges as hyperlinks to valid schemas & csvs
         v.delay.check_validation

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -90,7 +90,8 @@ class Validation
   def self.fetch_validation(id, format, revalidate = nil)
     # returns a mongo database record
     v = self.find(id)
-    unless revalidate === false
+
+    unless revalidate === "false"
       if ["png", "svg"].include?(format)
         # suspect the above functions tied to the use of badges as hyperlinks to valid schemas & csvs
         v.delay.check_validation

--- a/features/background_validation.feature
+++ b/features/background_validation.feature
@@ -1,12 +1,12 @@
 @javascript
 Feature: Background validation
-  
+
   Background:
     Given the fixture "csvs/valid.csv" is available at the URL "http://example.org/test.csv"
     Given the fixture "csvs/info.csv" is available at the URL "http://example.org/info.csv"
     Given the fixture "csvs/errors.csv" is available at the URL "http://example.org/errors.csv"
     Given the fixture "csvs/revalidate.csv" is available at the URL "http://example.org/revalidate.csv"
-  
+
   Scenario: Enter a URL for validation
     When I go to the homepage
     And I enter "http://example.org/test.csv" in the "url" field

--- a/features/step_definitions/background_validation_steps.rb
+++ b/features/step_definitions/background_validation_steps.rb
@@ -1,7 +1,7 @@
 require 'package_processor'
 
 Then(/^my CSV should be placed in a background job$/) do
-  Validation.any_instance.should_receive(:delay).and_call_original
+  Package.any_instance.should_receive(:delay).and_call_original
 end
 
 When(/^I wait for the ajax request to finish$/) do

--- a/spec/models/validation_spec.rb
+++ b/spec/models/validation_spec.rb
@@ -52,11 +52,25 @@ describe Validation, type: :model do
     Validation.fetch_validation(validation.id, "png", false)
   end
 
+  it "should not requeue a validation for images if revalidate is set to false as a string" do
+    mock_file("http://example.com/test.csv", 'csvs/valid.csv')
+    validation = Validation.create_validation("http://example.com/test.csv")
+    Validation.any_instance.should_not_receive(:delay)
+    Validation.fetch_validation(validation.id, "png", "false")
+  end
+
   it "should not revalidate for html if revalidate is set to false" do
     mock_file("http://example.com/test.csv", 'csvs/valid.csv')
     validation = Validation.create_validation("http://example.com/test.csv")
     Validation.any_instance.should_not_receive(:check_validation)
     Validation.fetch_validation(validation.id, "html", false)
+  end
+
+  it "should not revalidate for html if revalidate is set to false as a string" do
+    mock_file("http://example.com/test.csv", 'csvs/valid.csv')
+    validation = Validation.create_validation("http://example.com/test.csv")
+    Validation.any_instance.should_not_receive(:check_validation)
+    Validation.fetch_validation(validation.id, "html", "false")
   end
 
   it "should only create one validation per url" do


### PR DESCRIPTION
I noticed the Recent Validations page was running slowly. Digging in, it seems that the `fetch_validation` method expects a boolean value of `false`, but, because this is getting passed via a HTTP request, it's getting cast as a string. I've updated this so it'll work with boolean or string values, and added a few tests to catch both instances.