### PR TITLE
Feature file uploadtype

### DIFF
--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -27,11 +27,11 @@
           <label for="upload_file" class="options">Or upload a file:</label>
 
           <div class="input-group" id="streaming_graceful_fallback">
-            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'standard_files', multiple: 'multiple', accept: '.csv' %>
+            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'standard_files', multiple: 'multiple', accept: '.csv, .tsv, .txt' %>
             <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="resumable_streaming_files"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
           </div>
           <div class="input-group" id="streaming">
-            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'resumable_streaming_files', multiple: 'multiple', accept: '.csv' %>
+            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'resumable_streaming_files', multiple: 'multiple', accept: '.csv, .tsv, .txt' %>
             <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="resumable_streaming_files"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
             <div id="file_ids"></div>
           </div>
@@ -53,7 +53,7 @@
         <div class="checkbox">
           <label>
             <%= check_box_tag 'schema' %>
-            <%= label_tag 'schema', 'Add optional schema'%>
+            <%= label_tag 'schema', 'Add optional schema (in .json format)'%>
           </label>
         </div>
 

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -25,18 +25,15 @@
           </div>
 
           <label for="upload_file" class="options">Or upload a file:</label>
-
+            <!--the below divs are conditionally displayed depending on whether the resumable js library has a satisfactory browser environment-->
           <div class="input-group" id="streaming">
             <%= file_field_tag 'files[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
-
           </div>
-
           <div class="input-group" id="streaming_graceful_fallback">
             <%= file_field_tag 'files[]', id: 'standard_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
-
             <label style = "padding:8pt;" id="file_name"></label>
           </div>
-        <div id="file_ids"></div>
+          <div id="file_ids"></div>
           <div class="resumable-progress row">
             <div class="progress-container col-md-11">
               <div class="progress">
@@ -104,9 +101,10 @@ var r = new Resumable({
 });
 
 $('#streaming_graceful_fallback').addClass('hidden');
+$('#streaming').addClass('hidden');
 
 // Resumable.js isn't supported, fall back on a different method
-if(!r.support) {
+if(r.support) {
     console.log("support error");
     $('#streaming_graceful_fallback').removeClass('hidden');
     $('.resumable-error').show();

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -25,16 +25,14 @@
           </div>
 
           <label for="upload_file" class="options">Or upload a file:</label>
-
+        <div class="input-group">
+        <%= file_field_tag 'file[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', accept: '.csv, .tsv, .txt, .zip' %>
+        </div>
           <div class="input-group" id="streaming_graceful_fallback">
             <%= file_field_tag 'files[]', title: 'Choose Files', id: 'standard_files', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
-            <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="resumable_streaming_files"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
+            <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="streaming_graceful_fallback"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
           </div>
-          <div class="input-group" id="streaming">
-            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'resumable_streaming_files', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
-            <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="resumable_streaming_files"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
-            <div id="file_ids"></div>
-          </div>
+
 
           <div class="resumable-progress row">
             <div class="progress-container col-md-11">
@@ -111,7 +109,7 @@ if(!r.support) {
     $('.resumable-error').show();
 } else {
     $('#streaming').removeClass('hidden');
-    $('#resumable_streaming_files').addClass('hidden');
+//    $('#resumable_streaming_files').addClass('hidden');
     // Show a place for dropping/selecting files
     r.assignBrowse(document.getElementById('resumable_streaming_files'));
     // Handle file add event

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -25,9 +25,14 @@
           </div>
 
           <label for="upload_file" class="options">Or upload a file:</label>
-        <div class="input-group">
-        <%= file_field_tag 'file[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', accept: '.csv, .tsv, .txt, .zip' %>
+
+        <div class="input-group" id="streaming">
+          <%= file_field_tag 'files[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', accept: '.csv, .tsv, .txt, .zip' %>
+          <div id="file_ids"></div>
+          <label style = "padding:8pt;" id="file_name"></label>
         </div>
+
+
           <div class="input-group" id="streaming_graceful_fallback">
             <%= file_field_tag 'files[]', title: 'Choose Files', id: 'standard_files', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
             <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="streaming_graceful_fallback"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
@@ -200,29 +205,29 @@ if(!r.support) {
 		  e.preventDefault();
 		  $('#submit i').attr('class', 'fa fa-refresh fa-spin')
 
-  		  files = [];
-        urls = [];
-        paths = [];
-        validation_count = 0;
+  		    files = [];
+            urls = [];
+            paths = [];
+            validation_count = 0;
+            $.each($("#schema_file")[0].files, function(index, file) {
+                file.category = "schema"
+                files.push(file);
+            });
 
-  		  $.each($("#schema_file")[0].files, function(index, file) {
-  		    file.category = "schema"
-  		    files.push(file);
-  	    });
-
-        $( "#file_ids input" ).each(function(){
-          paths.push(this.value);
-          validation_count++;
-        })
-
-        $( "input[name='urls[]']" ).each(function(){
-          if ($(this).val().length > 0) {
-              urls.push($(this).val());
+            $( "#file_ids input" ).each(function(){
+              paths.push(this.value);
               validation_count++;
-          }
-        });
+            })
 
-  		  readFiles(files, function(files, schema_file) {
+            $( "input[name='urls[]']" ).each(function(){
+              if ($(this).val().length > 0) {
+                  urls.push($(this).val());
+                  validation_count++;
+              }
+            });
+            console.log("function that invokes postData");
+            console.log(files);
+            readFiles(files, function(files, schema_file) {
 
               postdata = {
                 "file_ids[]": paths,
@@ -231,10 +236,11 @@ if(!r.support) {
                 "schema_url": $('#schema_url').val(),
                 "urls[]": urls,
               }
+                console.log(JSON.stringify(postdata, null, 2));
               postData(postdata);
-  		  });
+            });
 
-		})
+		}) // end validation form submit
 
 		function readFiles(files, callback) {
 		  csvs = [];
@@ -276,6 +282,7 @@ if(!r.support) {
               type: "POST",
               data: data,
               success:function(data, textStatus, jqXHR) {
+                  console.log(data);
                 package_url = data.package.url
                 checkPackage();
               },

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -28,12 +28,12 @@
 
           <div class="input-group" id="streaming">
             <%= file_field_tag 'files[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
-            <div id="file_ids"></div>
+            <div class="file_ids"></div>
           </div>
 
           <div class="input-group" id="streaming_graceful_fallback">
             <%= file_field_tag 'files[]', id: 'standard_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
-            <div id="file_ids"></div>
+            <div class="file_ids"></div>
             <label style = "padding:8pt;" id="file_name"></label>
           </div>
 
@@ -141,7 +141,7 @@ if(!r.support) {
     r.on('fileSuccess', function(file,message){
         // Reflect that the file upload has completed
         $('.resumable-file-'+file.uniqueIdentifier+' .resumable-file-progress').html('(completed)');
-        $('#file_ids').append( "<input type='hidden' name='file_ids[]' value='" + file.uniqueIdentifier + "' />" )
+        $('.file_ids').append( "<input type='hidden' name='file_ids[]' value='" + file.uniqueIdentifier + "' />" )
     });
     r.on('fileError', function(file, message){
         // Reflect that the file upload has resulted in error
@@ -208,7 +208,7 @@ if(!r.support) {
                 files.push(file);
             });
 
-            $( "#file_ids input" ).each(function(){
+            $( "'.file_ids' input" ).each(function(){
               paths.push(this.value);
               validation_count++;
             })

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -24,6 +24,8 @@
             </div>
           </div>
 
+          <p class="more-information">Submitted urls are recorded in a public <a href="/validation">list of validation reports</a>. If you want to validate private data then upload a file from your computer, using the Browse button below.</p>
+
           <label for="upload_file" class="options">Or upload a file:</label>
             <!--the below divs are conditionally displayed depending on whether the resumable js library has a satisfactory browser environment-->
           <div class="input-group" id="streaming">
@@ -69,8 +71,6 @@
         <span class="spinner"><i class="glyphicon glyphicon-ok"></i></span>
         <%= t(:validate).titleize %>
       </button>
-
-      <p class="more-information">Submitted urls are recorded in a public <a href="/validation">list of validation reports</a>. If you want to validate private data then upload a file from your computer, using the Browse button below.</p>
       <% end %>
     <div class="resumable-error">
       Your browser, unfortunately, is not supported by Resumable.js. The library requires support for <a href="http://www.w3.org/TR/FileAPI/">the HTML5 File API</a> along with <a href="http://www.w3.org/TR/FileAPI/#normalization-of-params">file slicing</a>.

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -140,6 +140,7 @@ if(r.support) {
         // Reflect that the file upload has completed
         $('.resumable-file-'+file.uniqueIdentifier+' .resumable-file-progress').html('(completed)');
         $('#file_ids').append( "<input type='hidden' name='file_ids[]' value='" + file.uniqueIdentifier + "' />" )
+        // TODO this logic integral for correct function of async functions later
     });
     r.on('fileError', function(file, message){
         // Reflect that the file upload has resulted in error

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -104,15 +104,18 @@ $('#streaming_graceful_fallback').addClass('hidden');
 $('#streaming').addClass('hidden');
 
 // Resumable.js isn't supported, fall back on a different method
-if(r.support) {
+if(!r.support) {
     console.log("support error");
     $('#streaming_graceful_fallback').removeClass('hidden');
     $('.resumable-error').show();
 } else {
     $('#streaming').removeClass('hidden');
-//    $('#resumable_streaming_files').addClass('hidden');
     // Show a place for dropping/selecting files
     r.assignBrowse(document.getElementById('resumable_streaming_files'));
+    assignEventTriggers(r);
+}
+
+function assignEventTriggers(r){
     // Handle file add event
     r.on('fileAdded', function(file){
         // Show progress pabr
@@ -136,12 +139,14 @@ if(r.support) {
         $('.resumable-progress .progress-resume-link, .resumable-progress .progress-pause-link').hide();
 
     });
+
     r.on('fileSuccess', function(file,message){
         // Reflect that the file upload has completed
         $('.resumable-file-'+file.uniqueIdentifier+' .resumable-file-progress').html('(completed)');
         $('#file_ids').append( "<input type='hidden' name='file_ids[]' value='" + file.uniqueIdentifier + "' />" )
         // TODO this logic integral for correct function of async functions later
     });
+
     r.on('fileError', function(file, message){
         // Reflect that the file upload has resulted in error
         $('.resumable-file-'+file.uniqueIdentifier+' .resumable-file-progress').html('(file could not be uploaded: '+message+')');
@@ -174,7 +179,7 @@ if(r.support) {
 	});
 
 	$(document).ready( function() {
-	  var count = 1
+	  var count = 1; // TODO - what does this do?
 
 		$('.btn-file :file').on('fileselect', function(event, numFiles, label) {
 
@@ -192,8 +197,8 @@ if(r.support) {
 		  cloned.find('input:first').attr('id', 'url_' + count);
 		  $('.btn-clone:first').appendTo('.url-template:last');
 		  count = count + 1
-		})
-
+		});
+        console.log(r);
 		$('#validation_form').submit(function(e){
 		  e.preventDefault();
 		  $('#submit i').attr('class', 'fa fa-refresh fa-spin')

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -27,11 +27,11 @@
           <label for="upload_file" class="options">Or upload a file:</label>
 
           <div class="input-group" id="streaming_graceful_fallback">
-            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'standard_files', multiple: 'multiple', accept: '.csv, .tsv, .txt' %>
+            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'standard_files', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
             <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="resumable_streaming_files"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
           </div>
           <div class="input-group" id="streaming">
-            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'resumable_streaming_files', multiple: 'multiple', accept: '.csv, .tsv, .txt' %>
+            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'resumable_streaming_files', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
             <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="resumable_streaming_files"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
             <div id="file_ids"></div>
           </div>

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -198,7 +198,7 @@ function assignEventTriggers(r){
 		  $('.btn-clone:first').appendTo('.url-template:last');
 		  count = count + 1
 		});
-        console.log(r);
+
 		$('#validation_form').submit(function(e){
 		  e.preventDefault();
 		  $('#submit i').attr('class', 'fa fa-refresh fa-spin')

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -32,8 +32,9 @@
         </div>
 
           <div class="input-group" id="streaming_graceful_fallback">
-            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'standard_files', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
-            <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="streaming_graceful_fallback"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
+            <%= file_field_tag 'files[]', id: 'standard_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
+            <div id="file_ids"></div>
+            <label style = "padding:8pt;" id="file_name"></label>
           </div>
 
 

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -114,17 +114,6 @@ if(!r.support) {
     $('#resumable_streaming_files').addClass('hidden');
     // Show a place for dropping/selecting files
     r.assignBrowse(document.getElementById('resumable_streaming_files'));
-
-//    console.log(JSON.stringify(r,null,2));
-//    console.log(JSON.stringify(document.getElementById('upload_button'),null,2));
-//    console.log(document.getElementById('upload_button').childNodes);
-//    console.log(document.getElementsByClassName('input-group'));
-//    console.log(document.getElementById('upload_button').lastChild.setAttribute("accept", "text/csv"));
-//    console.log(document.getElementById('upload_button').lastChild);
-
-//    document.getElementById('upload_button').setAttribute("accept", "csv");
-//    r.assignBrowse(document.getElementById('standard_files'));
-
     // Handle file add event
     r.on('fileAdded', function(file){
         // Show progress pabr

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -8,7 +8,8 @@
     <p>CSVLint helps you to check that your CSV file is readable. And you can use it to check whether it contains the columns and types of values that it should.</p>
 
     <p>Just enter the location of the file you want to check, or upload it. If you have a schema which describes the
-    contents of the CSV file, you can also give its URL or upload it. <a href="/about">Read more...</a></p>
+    contents of the CSV file, you can also give its URL or upload it.</p>
+    <p>CSVLint currently only supports validation of delimiter-separated values (dsv) files. It is also possible to upload a .zip file of (dsv) files. <a href="/about">Read more...</a></p>
   </div>
   <div class="col-md-6 primary">
     <%= form_tag package_index_path, multipart: true, id: "validation_form" do %>
@@ -24,12 +25,15 @@
           </div>
 
           <label for="upload_file" class="options">Or upload a file:</label>
-          <div class="input-group">
-            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'standard_files', multiple: 'multiple' %>
-            <%= button_tag '<i class="glyphicon glyphicon-cloud-upload"></i> Choose a file'.html_safe, type: 'button', id: 'upload_button', class: 'btn-info btn-lg hidden' %>
-            <label style = "padding:8pt;" id="file_name"></label>
+
+          <div class="input-group" id="streaming_graceful_fallback">
+            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'standard_files', multiple: 'multiple', accept: '.csv' %>
+            <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="resumable_streaming_files"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
+          </div>
+          <div class="input-group" id="streaming">
+            <%= file_field_tag 'files[]', title: 'Choose Files', id: 'resumable_streaming_files', multiple: 'multiple', accept: '.csv' %>
+            <label id="browsebutton" style="font-weight: normal !important;" class="btn-info btn-lg text-right" for="resumable_streaming_files"><span style="margin-right:10px"><i class="glyphicon glyphicon-cloud-upload"></i></span>Choose A File</label>
             <div id="file_ids"></div>
-            <!--  add upload image back to button -->
           </div>
 
           <div class="resumable-progress row">
@@ -98,18 +102,28 @@ var r = new Resumable({
     }
 });
 
-$('#standard_files').addClass('hidden');
+$('#streaming_graceful_fallback').addClass('hidden');
 
 // Resumable.js isn't supported, fall back on a different method
 if(!r.support) {
     console.log("support error");
-    $('#standard_files').removeClass('hidden');
+    $('#streaming_graceful_fallback').removeClass('hidden');
     $('.resumable-error').show();
 } else {
-    $('#upload_button').removeClass('hidden');
+    $('#streaming').removeClass('hidden');
+    $('#resumable_streaming_files').addClass('hidden');
     // Show a place for dropping/selecting files
-    r.assignBrowse(document.getElementById('upload_button'));
+    r.assignBrowse(document.getElementById('resumable_streaming_files'));
 
+//    console.log(JSON.stringify(r,null,2));
+//    console.log(JSON.stringify(document.getElementById('upload_button'),null,2));
+//    console.log(document.getElementById('upload_button').childNodes);
+//    console.log(document.getElementsByClassName('input-group'));
+//    console.log(document.getElementById('upload_button').lastChild.setAttribute("accept", "text/csv"));
+//    console.log(document.getElementById('upload_button').lastChild);
+
+//    document.getElementById('upload_button').setAttribute("accept", "csv");
+//    r.assignBrowse(document.getElementById('standard_files'));
 
     // Handle file add event
     r.on('fileAdded', function(file){

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -27,10 +27,9 @@
           <label for="upload_file" class="options">Or upload a file:</label>
 
         <div class="input-group" id="streaming">
-          <%= file_field_tag 'files[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', accept: '.csv, .tsv, .txt, .zip' %>
+          <%= file_field_tag 'files[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
           <div id="file_ids"></div>
         </div>
-
 
           <div class="input-group" id="streaming_graceful_fallback">
             <%= file_field_tag 'files[]', title: 'Choose Files', id: 'standard_files', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -26,17 +26,16 @@
 
           <label for="upload_file" class="options">Or upload a file:</label>
 
-        <div class="input-group" id="streaming">
-          <%= file_field_tag 'files[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
-          <div id="file_ids"></div>
-        </div>
+          <div class="input-group" id="streaming">
+            <%= file_field_tag 'files[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
+            <div id="file_ids"></div>
+          </div>
 
           <div class="input-group" id="streaming_graceful_fallback">
             <%= file_field_tag 'files[]', id: 'standard_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
             <div id="file_ids"></div>
             <label style = "padding:8pt;" id="file_name"></label>
           </div>
-
 
           <div class="resumable-progress row">
             <div class="progress-container col-md-11">
@@ -220,8 +219,6 @@ if(!r.support) {
                   validation_count++;
               }
             });
-            console.log("function that invokes postData");
-            console.log(files);
             readFiles(files, function(files, schema_file) {
 
               postdata = {
@@ -277,8 +274,6 @@ if(!r.support) {
               type: "POST",
               data: data,
               success:function(data, textStatus, jqXHR) {
-                  console.log(data);
-                package_url = data.package.url
                 checkPackage();
               },
               error: function(req, textStatus, errorThrown){

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -28,15 +28,15 @@
 
           <div class="input-group" id="streaming">
             <%= file_field_tag 'files[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
-            <div class="file_ids"></div>
+
           </div>
 
           <div class="input-group" id="streaming_graceful_fallback">
             <%= file_field_tag 'files[]', id: 'standard_files', class: 'file-chooser btn-info btn-lg', title: 'browse', multiple: 'multiple', accept: '.csv, .tsv, .txt, .zip' %>
-            <div class="file_ids"></div>
+
             <label style = "padding:8pt;" id="file_name"></label>
           </div>
-
+        <div id="file_ids"></div>
           <div class="resumable-progress row">
             <div class="progress-container col-md-11">
               <div class="progress">
@@ -141,7 +141,7 @@ if(!r.support) {
     r.on('fileSuccess', function(file,message){
         // Reflect that the file upload has completed
         $('.resumable-file-'+file.uniqueIdentifier+' .resumable-file-progress').html('(completed)');
-        $('.file_ids').append( "<input type='hidden' name='file_ids[]' value='" + file.uniqueIdentifier + "' />" )
+        $('#file_ids').append( "<input type='hidden' name='file_ids[]' value='" + file.uniqueIdentifier + "' />" )
     });
     r.on('fileError', function(file, message){
         // Reflect that the file upload has resulted in error
@@ -208,7 +208,7 @@ if(!r.support) {
                 files.push(file);
             });
 
-            $( "'.file_ids' input" ).each(function(){
+            $( "#file_ids input" ).each(function(){
               paths.push(this.value);
               validation_count++;
             })
@@ -274,6 +274,7 @@ if(!r.support) {
               type: "POST",
               data: data,
               success:function(data, textStatus, jqXHR) {
+                package_url = data.package.url
                 checkPackage();
               },
               error: function(req, textStatus, errorThrown){

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -29,7 +29,6 @@
         <div class="input-group" id="streaming">
           <%= file_field_tag 'files[]', id: 'resumable_streaming_files', class: 'file-chooser btn-info btn-lg', title: 'browse', accept: '.csv, .tsv, .txt, .zip' %>
           <div id="file_ids"></div>
-          <label style = "padding:8pt;" id="file_name"></label>
         </div>
 
 
@@ -138,11 +137,7 @@ if(!r.support) {
     r.on('complete', function(){
         // Hide pause/resume when the upload has completed
         $('.resumable-progress .progress-resume-link, .resumable-progress .progress-pause-link').hide();
-        if (r.files.length == 1) {
-          document.getElementById("file_name").innerHTML = r.files[0].file.name;
-        } else {
-          document.getElementById("file_name").innerHTML = r.files.length + " files"
-        }
+
     });
     r.on('fileSuccess', function(file,message){
         // Reflect that the file upload has completed


### PR DESCRIPTION
this makes amendments to the text on homepage to be more explicit about files which can be processed. I have used the following description - please advise if it needs amending

`CSVLint currently only supports validation of delimiter-separated values (dsv) files. It is also possible to upload a .zip file of (dsv) files`

Other changes are made to restrict the types of file that the file uploaded will permit the user to attach to `.csv, .tsv, .txt .zip`

The above change meant that the button display had to amended. An inline styling horror show is viewable here - suspect that I should move the styling to a CSS file but await best advise
https://github.com/theodi/csvlint/blob/feature-file-uploadtype/app/views/application/index.html.erb#L31