### PR TITLE
Bump CSVlint Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,12 +127,14 @@ GEM
       thor (= 0.18.1)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    csvlint (0.1.4)
+    csvlint (0.2.0)
       activesupport
       addressable
       colorize
+      escape_utils
       mime-types
       open_uri_redirections
+      uri_template
     cucumber (1.3.20)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -166,6 +168,7 @@ GEM
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
+    escape_utils (1.1.0)
     ethon (0.7.4)
       ffi (>= 1.3.0)
     eventmachine (1.0.7)
@@ -276,7 +279,7 @@ GEM
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
-    mime-types (2.6.1)
+    mime-types (2.6.2)
     mini_portile (0.6.2)
     minitest (4.7.5)
     mongoid (4.0.2)
@@ -483,10 +486,11 @@ GEM
       coffee-rails
     typhoeus (0.7.2)
       ethon (>= 0.7.4)
-    tzinfo (0.3.44)
+    tzinfo (0.3.45)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    uri_template (0.7.0)
     vcr (2.9.3)
     webmock (1.21.0)
       addressable (>= 2.3.6)

--- a/app/controllers/schemas_controller.rb
+++ b/app/controllers/schemas_controller.rb
@@ -17,7 +17,7 @@ class SchemasController < ApplicationController
   
   def show
     @db_schema = Schema.where(id: params[:id]).first
-    @schema = Csvlint::Schema.load_from_json_table(@db_schema.url)
+    @schema = Csvlint::Schema.load_from_json(@db_schema.url)
     respond_to do |wants|
       wants.html
       wants.csv { send_data example_csv(@schema), type: "text/csv; charset=utf-8", disposition: "attachment" }

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -170,7 +170,7 @@ class Validation
   end
 
   def update_validation(dialect = nil, expiry=nil)
-    loaded_schema = schema ? Csvlint::Schema.load_from_json_table(schema.url) : nil
+    loaded_schema = schema ? Csvlint::Schema.load_from_json(schema.url) : nil
     validation = Validation.validate(self.url || self.csv, schema.try(:url), loaded_schema, dialect, expiry)
     self.update_attributes(validation)
     # update mongoDB record

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -240,6 +240,7 @@ class Validation
   end
 
   def self.generate_options(dialect)
+    dialect ||= {}
     {
       col_sep: dialect["delimiter"],
       row_sep: dialect["lineTerminator"],

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -57,6 +57,7 @@ class Validation
       # It's a file!
       url = nil
       validator.remove_instance_variable(:@source)
+      validator.remove_instance_variable(:@source_url) if validator.instance_variable_defined?(:@source_url)
     end
 
     # Don't save the data

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -74,6 +74,9 @@ VCR.configure do |c|
   c.cassette_library_dir = 'features/cassettes'
   c.default_cassette_options = { :record => :once }
   c.ignore_hosts "static.dev", "127.0.0.1"
+  c.ignore_request do |request|
+    request.uri.match /(.+)?[example|gov|githubusercontent]\..+/
+  end
 end
 
 VCR.cucumber_tags do |t|

--- a/lib/schema_processor.rb
+++ b/lib/schema_processor.rb
@@ -21,7 +21,7 @@ class SchemaProcessor
   end
 
   def from_url
-    Csvlint::Schema.load_from_json_table(@url)
+    Csvlint::Schema.load_from_json(@url)
   end
 
   def from_data

--- a/spec/models/package_spec.rb
+++ b/spec/models/package_spec.rb
@@ -48,7 +48,7 @@ describe Package, type: :model do
       schema_url = "http://example.org/schema.json"
       mock_file(schema_url, 'schemas/valid.json', 'application/javascript')
 
-      schema = Csvlint::Schema.load_from_json_table(schema_url)
+      schema = Csvlint::Schema.load_from_json(schema_url)
       package = Package.new
       package = package.create_package(@urls, schema_url, schema)
 
@@ -87,7 +87,7 @@ describe Package, type: :model do
       schema_url = "http://example.org/schema.json"
       mock_file(schema_url, 'schemas/valid.json', 'application/javascript')
 
-      schema = Csvlint::Schema.load_from_json_table(schema_url)
+      schema = Csvlint::Schema.load_from_json(schema_url)
       package = Package.new
       package = package.create_package(@files, schema_url, schema)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,9 @@ VCR.configure do |c|
   c.default_cassette_options = { :record => :once }
   c.hook_into :webmock
   c.configure_rspec_metadata!
+  c.ignore_request do |request|
+    request.uri.match /(.+)?[example|gov]\..+/
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This bumps the CSVlint version to `0.2.0` and fixes a few bugs that were introduced. It will also *potentially* allow CSV on the Web Validation, though this is untested, and some error messages will need translations adding. This can be addressed later though.