### PR TITLE
Speed up validations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       thor (= 0.18.1)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    csvlint (0.2.1)
+    csvlint (0.2.2)
       activesupport
       addressable
       colorize

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,6 @@ GEM
       escape_utils
       mime-types
       open_uri_redirections
-      typhoeus
       uri_template
     cucumber (1.3.20)
       builder (>= 2.1.2)
@@ -170,7 +169,7 @@ GEM
       nokogiri (>= 1.4.3)
     erubis (2.7.0)
     escape_utils (1.1.0)
-    ethon (0.8.0)
+    ethon (0.7.4)
       ffi (>= 1.3.0)
     eventmachine (1.0.7)
     execjs (2.5.2)
@@ -485,8 +484,8 @@ GEM
       typhoeus (~> 0.6, >= 0.6.8)
     turbolinks (2.5.3)
       coffee-rails
-    typhoeus (0.8.0)
-      ethon (>= 0.8.0)
+    typhoeus (0.7.2)
+      ethon (>= 0.7.4)
     tzinfo (0.3.45)
     uglifier (2.7.1)
       execjs (>= 0.3.0)

--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -40,7 +40,7 @@ module ValidationHelper
     if validator.headers
       validator.headers.each do |k,v|
         key = "header_#{k.gsub("-", "_")}".to_sym
-        variables[key.downcase] = v
+        variables[key] = v
       end
     end
 

--- a/app/models/validation.rb
+++ b/app/models/validation.rb
@@ -36,7 +36,7 @@ class Validation
     end
 
     # Validate
-    validator = Csvlint::Validator.new( io, (dialect || {}), schema && schema.fields.empty? ? nil : schema )
+    validator = Csvlint::Validator.new( io, dialect, schema && schema.fields.empty? ? nil : schema )
     # ternary evaluation above follows the following format::  condition ? if_true : if_false
     check_schema(validator, schema) unless schema.nil?
     # in prior versions this method only executed on schema_url.nil, a condition that caused some schema uploads to pass
@@ -62,12 +62,6 @@ class Validation
 
     # Don't save the data
     validator.remove_instance_variable(:@data) rescue nil
-    # Don't save the lambda either
-    validator.remove_instance_variable(:@lambda) rescue nil
-
-    # Headers are set as a Typhoeus::Response::Header, but this has a proc, so we cast as a hash
-    # TODO: We really need to stop dumping the whole object here
-    validator.instance_variable_set("@headers", {}.merge(validator.headers))
 
     attributes = {
       :url => url,


### PR DESCRIPTION
While going through some optimisation work on the CSVlint gem, I noticed that validations were taking considerably longer than in the gem. I expected a little bit of latency, but not this much. 

After some digging, I found that to work out if a file is a CKAN dataset or a Datapackage, we were using all of Datakitten's functionality, including `detect_origin` and `detect_host`, as well as doing some RDF checking. Each one of these checks is very expensive and requires a whole bunch of HTTP requests.

I've therefore monkey-patched the stuff we need into a `RemoteDataset` class, which only does the things we need, namely checking if a dataset is a CKAN dataset or a Datapackage. We're now seeing a bit of latency, but it's still almost 5x(!) faster.