### PR TITLE
Monkey patch line_breaks method 

### DIFF
--- a/app/helpers/validation_helper.rb
+++ b/app/helpers/validation_helper.rb
@@ -1,3 +1,18 @@
+# Monkey patch line_breaks method to handle older Validator objects that store @line_breaks as strings
+
+module Csvlint
+  class Validator
+    def line_breaks
+      @line_breaks = [@line_breaks].flatten
+      if @line_breaks.uniq.count > 1
+        :mixed
+      else
+        @line_breaks.uniq.first
+      end
+    end
+  end
+end
+
 module ValidationHelper
 
   def error_and_warning_count(errors, warnings, options)


### PR DESCRIPTION
Older `CSVLint::Validator` objects store `@line_breaks` as a string, and https://github.com/theodi/csvlint.rb/commit/a4eac40422e86f706466c2e8cca5d7e2364e2250 breaks these. This is a quick monkey patch that gets round this by setting the instance variable as a single item array if it's a string.