### PR TITLE
Limit filesize

### DIFF
--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -93,6 +93,7 @@ var r = new Resumable({
     chunkSize:1*1024*1024,
     simultaneousUploads:4,
     testChunks:false,
+    maxFileSize: 200*1024*1024, // Limit filesize to 200MB
     throttleProgressCallbacks:1,
     generateUniqueIdentifier: function(file) {
       var relativePath = file.webkitRelativePath||file.fileName||file.name; // Some confusion in different versions of Firefox


### PR DESCRIPTION
Our DB is getting choked with massive files, even though we're performing a cleanup every day. Long term, we need to think of a better solution to this than storing in Mongo.