### PR TITLE
Show progress bar for schema upload

### DIFF
--- a/app/assets/javascripts/bootstrap.file-input.js
+++ b/app/assets/javascripts/bootstrap.file-input.js
@@ -102,7 +102,7 @@ $.fn.bootstrapFileInput = function(prependIcon) {
         fileName = fileName.substring(fileName.lastIndexOf('\\')+1,fileName.length);
       }
 
-      $(this).parent().after('<span class="file-input-name">'+fileName+'</span>');
+      //$(this).parent().after('<span class="file-input-name">'+fileName+'</span>');
     });
 
   });

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -279,3 +279,13 @@ font-weight: bold;
   height: 30px;
   width: 100%;
 }
+
+.schema-text {
+  overflow: auto;
+  margin-left: -20px;
+  font-size: 0.9em;
+}
+
+.schema-progress-container {
+  margin: 15px 0 5px -15px;
+}

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -65,6 +65,19 @@
             <div class="input-group">
               <%= file_field_tag 'schema_file', class: 'file-chooser btn-info btn-lg', title: 'browse' %>
             </div>
+
+            <div class="schema-progress-container row hidden">
+              <div class="col-md-11">
+                <div class="progress">
+                  <div class="schema-progress-bar progress-bar" role="progressbar"></div>
+                </div>
+
+                <ul class="schema-text hidden">
+
+                </ul>
+              </div>
+            </div>
+
             <input type="hidden" name="file_ids[]" />
       </div>
 
@@ -197,6 +210,19 @@ function assignEventTriggers(r){
 		$('#schema').prop('checked', false).click(function() {
 		  $('#schemas').toggleClass('hidden', !this.checked)
 		})
+
+    $('#schema_file').change(function() {
+      $('.schema-progress-bar').width('0')
+      $('.schema-progress-container').removeClass('hidden');
+      var fileName = $(this).val().split('\\').reverse()[0];
+      $('.schema-text').removeClass('hidden');
+      $('.schema-text').append('<li>')
+      var li = $('.schema-text').find('li')
+      li.html('Uploading ' + fileName )
+      $('.schema-progress-bar').animate({width: '100%'}, 1200, 'swing', function() {
+        li.html('Uploading ' + fileName + ' (completed)' )
+      })
+    })
 
 		$('.btn-clone').click(function() {
 		  cloned = $('.url-template:first').clone().appendTo('#url').removeClass('hidden');


### PR DESCRIPTION
Fixes #250

This is a UI fix that just shows a fake progress bar for schemas to match how the CSVs are presented. We could use resumable upload for this, but given that the schemas are unlikely to be any bigger than a few k, seems redundant and would require a helluva lot of unpicking.